### PR TITLE
Emit type declarations

### DIFF
--- a/dist/morphlite.d.ts
+++ b/dist/morphlite.d.ts
@@ -1,0 +1,1 @@
+export declare function morph(node: Node, guide: Node): void;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.1",
 	"description": "Morphlite is an attempt to create a DOM morphing function in less than 100 lines of code to use with [HTMZ](https://leanrada.com/htmz/) in small projects.",
 	"main": "dist/morphlite.js",
+	"types": "dist/morphlite.d.ts",
 	"scripts": {
 		"test": "web-test-runner test/**/*.test.js --node-resolve",
 		"build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"outDir": "dist",
 		"baseUrl": ".",
 		"noEmit": false,
-		"declaration": false,
+		"declaration": true,
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true
 	}


### PR DESCRIPTION
This pull request sets up `tsc` to also emit `.d.ts` type declarations into `dist/` in the build step. By also adding the `types` field in the `package.json` it allows consumers of the package to get type annotations.